### PR TITLE
Check for ActiveSupport::BufferedLogger and use it if it is defined.

### DIFF
--- a/lib/le.rb
+++ b/lib/le.rb
@@ -21,6 +21,9 @@ module Le
     elsif defined?(ActiveSupport::Logger)
       logger = ActiveSupport::Logger.new(host)
       logger.formatter = host.formatter if host.respond_to?(:formatter)
+    elsif defined?(ActiveSupport::BufferedLogger)
+      logger = ActiveSupport::BufferedLogger.new(host)
+      logger.formatter = host.formatter if host.respond_to?(:formatter)
     else
       logger = Logger.new(host)
       logger.formatter = host.formatter if host.respond_to?(:formatter)


### PR DESCRIPTION
`ComfortableMexicanSofa` defines custom methods on this logger which fail with logentries. Hoping this will fix that. Alternatively we could make a change to CMS.

See comfy/comfortable-mexican-sofa#306.
